### PR TITLE
Corrected 'spelling'

### DIFF
--- a/source/docs/shapes/Arrow.md
+++ b/source/docs/shapes/Arrow.md
@@ -1,7 +1,7 @@
 title: Arrow Tutorial
 ---
 
-To create  a circle with `Konva`, we can instantiate a `Konva.Arrow()` object.
+To create an arrow with `Konva`, we can instantiate a `Konva.Arrow()` object.
 
 For a full list of attributes and methods, check out the [Konva.Arrow documentation](http://konvajs.github.io/api/Konva.Arrow.html).
 

--- a/source/downloads/code/shapes/Arrow.html
+++ b/source/downloads/code/shapes/Arrow.html
@@ -30,7 +30,6 @@
     var arrow = new Konva.Arrow({
       x: stage.getWidth() / 4,
       y: stage.getHeight() / 4,
-      radius: 70,
       points: [0,0, width / 2, height / 2],
       pointerLength: 20,
       pointerWidth : 20,

--- a/source/downloads/code/shapes/Arrow.html
+++ b/source/downloads/code/shapes/Arrow.html
@@ -27,7 +27,7 @@
 
     var layer = new Konva.Layer();
 
-    var circle = new Konva.Arrow({
+    var arrow = new Konva.Arrow({
       x: stage.getWidth() / 4,
       y: stage.getHeight() / 4,
       radius: 70,
@@ -40,7 +40,7 @@
     });
 
     // add the shape to the layer
-    layer.add(circle);
+    layer.add(arrow);
 
     // add the layer to the stage
     stage.add(layer);


### PR DESCRIPTION
Arrow shape was incorrectly labelled ‘circle’ in documentation.