### PR TITLE
Event type 'mousewheel' has changed to 'wheel'

### DIFF
--- a/source/docs/events/Binding_Events.md
+++ b/source/docs/events/Binding_Events.md
@@ -4,7 +4,7 @@ title: HTML5 Canvas Shape Events
 To detect shape events with Konva, we can use the `on()` method to bind event handlers to a node.
 
 The `on()` method requires an event type and a function to be executed when the event occurs.
-Konva supports `mouseover`, `mouseout`, `mouseenter`, `mouseleave`, `mousemove`, `mousedown`, `mouseup`, `mousewheel`, `click`, `dblclick`, `dragstart`, `dragmove`, and `dragend` desktop events.
+Konva supports `mouseover`, `mouseout`, `mouseenter`, `mouseleave`, `mousemove`, `mousedown`, `mouseup`, `wheel`, `click`, `dblclick`, `dragstart`, `dragmove`, and `dragend` desktop events.
 
 Instructions: Mouseover and mouseout of the triangle, and mouseover, mouseout, mousedown, and mouseup over the circle.
 


### PR DESCRIPTION
Updates documentation to reflect the name change of the 'mousewheel' event type to 'wheel'.