### PR TITLE
Add layer.draw() to minimal example

### DIFF
--- a/source/docs/overview.md
+++ b/source/docs/overview.md
@@ -78,6 +78,9 @@ layer.add(circle);
 
 // add the layer to the stage
 stage.add(layer);
+
+// draw the image
+layer.draw();
 ```
 Result:
 ![Minimal code demo](/assets/overview-circle.png)


### PR DESCRIPTION
The minimal example in overview.md needs a call to `layer.draw();` to render anything.