### PR TITLE
Fix a wrong link

### DIFF
--- a/source/docs/performance/All_Performance_Tips.md
+++ b/source/docs/performance/All_Performance_Tips.md
@@ -15,7 +15,7 @@ Here is list of useful performance tips:
 4. [Optimize Animation](https://konvajs.github.io/docs/performance/Optimize_Animation.html)
 5. [Shape Redraw](https://konvajs.github.io/docs/performance/Shape_Redraw.html)
 6. If your shape has only position transformation (`x` and `y`, no `scale`, `rotation`) set `transformsEnabled = 'position'`
-7. If you don't need event on layer set `layer.hitGraphEnabled(false)`. Or use [Konva.FastLayer](https://konvajs.github.io/api/Konva.Group.html). See [Demo](https://konvajs.github.io/docs/sandbox/Animation_Stress_Test.html)
+7. If you don't need event on layer set `layer.hitGraphEnabled(false)`. Or use [Konva.FastLayer](https://konvajs.github.io/api/Konva.FastLayer.html). See [Demo](https://konvajs.github.io/docs/sandbox/Animation_Stress_Test.html)
 8. For mobile application set viewport: `<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">`
 9. If you have bad performance on retina devices set `Konva.pixelRatio = 1`. Make sure that quality of result is ok for you.
 10. While dragging a node you can move it on separate layer. Then move it back to original layer. See [Demo](https://konvajs.github.io/docs/sandbox/Drag_and_Drop_Stress_Test.html)


### PR DESCRIPTION
The label `FastLayer` was linked to docs of `Group` instead of `FastLayer`.