### PR TITLE
use existing variable

### DIFF
--- a/source/downloads/code/sandbox/Drop_DOM_Element.html
+++ b/source/downloads/code/sandbox/Drop_DOM_Element.html
@@ -51,7 +51,7 @@
             e.preventDefault(); // !important
         });
 
-        stage.getContainer().addEventListener('drop', function (e) {
+        con.addEventListener('drop', function (e) {
             e.preventDefault();
             // now we need to find pointer position
             // we can't use stage.getPointerPosition() here, because that event


### PR DESCRIPTION
tiny documentation change. use an existing variable instead of getting the container again.