### PR TITLE
fixed destroy usage on shape collection

### DIFF
--- a/source/downloads/code/select_and_transform/Basic_demo.html
+++ b/source/downloads/code/select_and_transform/Basic_demo.html
@@ -56,7 +56,7 @@
       stage.on('click tap', function(e) {
         // if click on empty area - remove all transformers
         if (e.target === stage) {
-          stage.find('Transformer').destroy();
+          stage.find('Transformer').each(el => el.destroy());
           layer.draw();
           return;
         }
@@ -66,7 +66,7 @@
         }
         // remove old transformers
         // TODO: we can skip it if current rect is already selected
-        stage.find('Transformer').destroy();
+        stage.find('Transformer').each(el => el.destroy());
 
         // create new transformer
         var tr = new Konva.Transformer();


### PR DESCRIPTION
`stage.find('Transformer')` returns collection with no destroy function. Used `each` method to call `destroy()` on all the shapes in the collection