### PR TITLE
chore: rename yokanban to taggle

### DIFF
--- a/source/index.jade
+++ b/source/index.jade
@@ -99,11 +99,11 @@ comments: false
                 p A programming language for drawing
 
           .grid-item.small
-            a(href="https://yokanban.io/", target="_blank")
+            a(href="https://taggle.so.io/", target="_blank")
               .preview(style='background-image: url(/assets/users/yokanban.jpg);')
               .description
-                h5.name yokanban.io
-                p A new Kanban tool
+                h5.name Taggle.so
+                p A modern project management whiteboard that inspires flow and communication
 
           .grid-item.small
             a(href="https://boardos.online", target="_blank")


### PR DESCRIPTION
Hey there!

I'm one of the developers at Taggle (formerly yokanban). We've recently renamed our tool to Taggle and this PR changes this on the website  :)