### PR TITLE
Fix vue save/load example to respect initial list data

### DIFF
--- a/vue-demos/save-load/src/App.vue
+++ b/vue-demos/save-load/src/App.vue
@@ -10,9 +10,7 @@
         <v-circle
           v-for="item in list"
           :key="item.id"
-          :config="{
-            x : item.x, y: item.y, radius: 50, fill: 'red',
-          }"></v-circle>
+          :config="item"></v-circle>
       </v-layer>
       <v-layer ref="dragLayer"></v-layer>
     </v-stage>
@@ -37,14 +35,18 @@ export default {
     handleClick(evt) {
       const stage = evt.target.getStage();
       const pos = stage.getPointerPosition();
-      this.list.push(pos);
+      this.list.push({
+        radius: 50,
+        fill: 'red',
+        ...pos
+      });
 
       this.save();
     },
 
     load() {
-      const data = localStorage.getItem('storage') || '[]';
-      this.list = JSON.parse(data);
+      const data = localStorage.getItem('storage');
+      if (data) this.list = JSON.parse(data);
     },
 
     save() {


### PR DESCRIPTION
I don't think the current vue save/load example makes sense. The list is defined with some initial data (blue circle) which is never actually used. Changed it so that it is used as initial data and correctly rendered to the canvas alongside the red circles added by the user.

Not sure what the initial intention behind this was, but I think that might have been the desired behavior, otherwise just ignore this  pr :D