### PR TITLE
Change vue z-index demo to show App.vue initially instead of main.js

### DIFF
--- a/source/docs/vue/zIndex.md
+++ b/source/docs/vue/zIndex.md
@@ -15,4 +15,4 @@ Don't use the `zIndex` for your canvas components.
 Instructions: Try to drag a circle. See how it goes to the top. We are doing this by manipulating the data of the app so that the circles inside the `<template>` maintain the correct order.
 
 
-<iframe src="https://codesandbox.io/embed/github/konvajs/site/tree/master/vue-demos/zIndex?hidenavigation=1&view=split&fontsize=10" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/konvajs/site/tree/master/vue-demos/zIndex?hidenavigation=1&view=split&fontsize=10&module=/src/App.vue" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>


### PR DESCRIPTION
See title, currently showing main.js as default in the sandbox