### PR TITLE
add getting started page link to svelte main menu element

### DIFF
--- a/content/docs/svelte/_category_.json
+++ b/content/docs/svelte/_category_.json
@@ -1,5 +1,8 @@
 {
   "label": "Svelte",
   "position": 21,
-  "link": null
+  "link": {
+    "type": "doc",
+    "id": "docs/svelte/index"
+  }
 }


### PR DESCRIPTION
Adds a link to the top-level svelte navigation item which points to the getting started page (like vue and react docs)