### PR TITLE
Fix wrong table formatting due to types

### DIFF
--- a/content/api/Konva.Animation.mdx
+++ b/content/api/Konva.Animation.mdx
@@ -18,7 +18,7 @@ Animation constructor.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | func | `AnimationFn` | function executed on each animation frame.  The function is passed a frame object, which contains  timeDiff, lastTime, time, and frameRate properties.  The timeDiff property is the number of milliseconds that have passed  since the last animation frame. The time property is the time in milliseconds that elapsed from the moment the animation started  to the current animation frame. The lastTime property is a `time` value from the previous frame.  The frameRate property is the current frame rate in frames / second.  Return false from function, if you don't need to redraw layer/layers on some frames. |
-| layers (optional) | `Konva.Layer|Array` | layer(s) to be redrawn on each animation frame. Can be a layer, an array of layers, or null.  Not specifying a node will result in no redraw. |
+| layers (optional) | `Konva.Layer\|Array` | layer(s) to be redrawn on each animation frame. Can be a layer, an array of layers, or null.  Not specifying a node will result in no redraw. |
 
 ## Own Methods
 

--- a/content/api/Konva.Stage.mdx
+++ b/content/api/Konva.Stage.mdx
@@ -18,7 +18,7 @@ Stage constructor.  A stage is used to contain multiple layers
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | config | `Object` |  |
-| container | `String|Element` | Container selector or DOM element |
+| container | `String\|Element` | Container selector or DOM element |
 | x (optional) | `Number` |  |
 | y (optional) | `Number` |  |
 | width (optional) | `Number` |  |

--- a/create-api-docs.js
+++ b/create-api-docs.js
@@ -178,7 +178,7 @@ ${docItem.longname === 'Konva' ? 'sidebar_position: 1' : ''}
       markdown += `| ---- | ---- | ----------- |\n`;
       docItem.params.forEach((param) => {
         const name = param.name.replace('config.', '');
-        const type = param.type ? param.type.names.join('|') : 'any';
+        const type = param.type ? param.type.names.join('\\|') : 'any';
         const description = param.description
           ? processDescription(param.description)
           : '';


### PR DESCRIPTION
Typescript OR caused tables to be rendered wrongly, now escaped