### PR TITLE
Fix React example in Listening_False.mdx

### DIFF
--- a/content/docs/performance/Listening_False.mdx
+++ b/content/docs/performance/Listening_False.mdx
@@ -84,21 +84,21 @@ layer.add(text);
 import { Stage, Layer, Circle, Text } from 'react-konva';
 import { useState } from 'react';
 
+// Generate circles data
+const listeningCircles = Array.from({ length: 100 }, (_, i) => ({
+  id: i,
+  x: Math.random() * window.innerWidth,
+  y: Math.random() * window.innerHeight,
+}));
+
+const nonListeningCircles = Array.from({ length: 1000 }, (_, i) => ({
+  id: i + 100,
+  x: Math.random() * window.innerWidth,
+  y: Math.random() * window.innerHeight,
+}));
+
 const App = () => {
   const [hoveredId, setHoveredId] = useState(null);
-  
-  // Generate circles data
-  const listeningCircles = Array.from({ length: 100 }, (_, i) => ({
-    id: i,
-    x: Math.random() * window.innerWidth,
-    y: Math.random() * window.innerHeight,
-  }));
-  
-  const nonListeningCircles = Array.from({ length: 1000 }, (_, i) => ({
-    id: i + 100,
-    x: Math.random() * window.innerWidth,
-    y: Math.random() * window.innerHeight,
-  }));
 
   return (
     <Stage width={window.innerWidth} height={window.innerHeight}>
@@ -133,7 +133,7 @@ const App = () => {
         <Text
           x={10}
           y={10}
-          text="Blue circles (100) have event listeners (hover them)\nGreen circles (1000) have no listeners (better performance)"
+          text={"Blue circles (100) have event listeners (hover them)\nGreen circles (1000) have no listeners (better performance)"}
           fontSize={16}
           fill="black"
         />


### PR DESCRIPTION
The React example in Listening False has two bugs: 1) changing hoveredId state triggers a re-render forcing a new circle calculation & re-render of the circles, 2) text is displayed improperly