### PR TITLE
Update 11_Resize_Text.mdx

### DIFF
--- a/content/docs/select_and_transform/11_Resize_Text.mdx
+++ b/content/docs/select_and_transform/11_Resize_Text.mdx
@@ -66,7 +66,7 @@ import { Stage, Layer, Text, Transformer } from 'react-konva';
 import { useRef, useEffect, useState } from 'react';
 
 const App = () => {
-  const [textWidth, setTextWidth] = useState(200);
+  const [textWidth, setTextWidth] = useState();  
   const textRef = useRef();
   const trRef = useRef();
 
@@ -83,7 +83,7 @@ const App = () => {
           text="Hello from Konva! Try to resize me."
           fontSize={24}
           draggable
-          width={textWidth}
+          width={undefined || textWidth}
           ref={textRef}
           onTransform={() => {
             const node = textRef.current;
@@ -163,3 +163,4 @@ onMounted(() => {
   </TabItem>
 </Tabs>
 ```
+


### PR DESCRIPTION
With this small adjustment of using `undefined` and initializing `textWidth` with `null`, the text is generated with an automatically adjusted transformer, and resizing can be done normally.